### PR TITLE
feat: add modelName to monitoring payload (v1.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "olakai-sdk"
-version = "1.2.0"
+version = "1.3.0"
 description = "Auto-instrumentation SDK for monitoring and tracking LLM usage (OpenAI, Anthropic, etc.)"
 authors = [
     { name="Olakai", email="support@olakai.ai" }

--- a/src/olakaisdk/extractors/openai_extractor.py
+++ b/src/olakaisdk/extractors/openai_extractor.py
@@ -87,7 +87,8 @@ class OpenAIExtractor(BaseExtractor):
             task=context_data.task,
             subTask=context_data.subTask,
             customData=custom_data,
-            shouldScore=True
+            shouldScore=True,
+            modelName=model,
         )
 
         return payload

--- a/src/olakaisdk/shared/types.py
+++ b/src/olakaisdk/shared/types.py
@@ -69,6 +69,7 @@ class MonitorPayload:
     sensitivity: Optional[List[str]] = None
     customData: Optional[Dict[str, Union[str, int, float, bool]]] = None
     shouldScore: Optional[bool] = True
+    modelName: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add `modelName: Optional[str] = None` to `MonitorPayload` dataclass
- OpenAI extractor now sets `modelName` from extracted model name
- Keeps `customData["model"]` for backward compatibility
- Version bump to **1.3.0**

## Test plan
- [x] `python3 -m py_compile` passes for modified files
- [ ] `instrument_openai()` → verify `modelName` appears in monitoring payload
- [ ] Backward compatible — `modelName` is optional, existing code unaffected