### PR TITLE
feat: add olakai_feedback() for explicit user feedback reporting (v1.4.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Olakai Python SDK v1.0.0 is an **auto-instrumentation SDK** for monitoring LLM u
 - **Auto-instrumentation**: Monkey-patches OpenAI SDK to automatically track all calls
 - **Context-based metadata**: Use `olakai_context()` to add user/custom data
 - **Manual event reporting**: Use `olakai_event()` to send custom event reports
+- **User feedback reporting**: Use `olakai_feedback()` to report thumbs up/down on a prior interaction
 - **Unified customData**: Single `customData` field for all custom metadata (replaces `customDimensions`/`customMetrics`)
 - **Streaming support**: Buffers streaming responses and sends telemetry when complete
 - **Server-focused**: Designed for backend applications (FastAPI, Flask, Django)
@@ -115,7 +116,7 @@ src/olakaisdk/
 │   ├── __init__.py
 │   ├── types.py             # OlakaiConfig, MonitorPayload, etc.
 │   └── exceptions.py
-├── core.py                  # Core API (olakai, olakai_event, olakai_monitor)
+├── core.py                  # Core API (olakai, olakai_event, olakai_feedback, olakai_monitor)
 └── monitor/                 # Legacy decorator (olakai_supervisor)
     ├── __init__.py
     └── decorator.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Olakai Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-04-07
+
+### Added
+
+- `olakai_feedback()` - New function for reporting explicit user feedback
+  (thumbs up/down) on a prior agent interaction. Fire-and-forget, never
+  raises. Wraps the existing monitoring pipeline with a well-known
+  `eventType="feedback"` convention in `customData`, so no server
+  changes are required.
+
 ## [1.0.0] - 2025-01-07
 
 ### 🎉 First Stable Release

--- a/README.md
+++ b/README.md
@@ -393,6 +393,44 @@ olakai_event(OlakaiEventParams(
 
 ---
 
+#### `olakai_feedback(session_id, rating, *, turn_index=None, comment=None, user_email=None, custom_data=None)`
+
+Report explicit user feedback (thumbs up/down) on a prior agent
+interaction. Fire-and-forget, like `olakai_event()` — never raises.
+
+Feedback is reported against a session, so `session_id` should
+match the session/chat ID used when the original interaction was
+reported. Optionally, `turn_index` can be used for turn-level
+feedback correlation within a multi-turn conversation.
+
+**Parameters:**
+
+- `session_id` (str): The session/conversation ID of the interaction being rated
+- `rating` (`"UP"` | `"DOWN"`): The user's feedback
+- `turn_index` (int, optional): Zero-based turn index within the session
+- `comment` (str, optional): Free-text comment alongside the rating
+- `user_email` (str, optional): Override for the user who gave the feedback
+- `custom_data` (dict, optional): Customer-defined fields for domain context
+
+**Example:**
+
+```python
+from olakaisdk import olakai_feedback
+
+# Thumbs-up on turn 3 of a specific chat session
+olakai_feedback(
+    session_id="chat_abc123",
+    rating="UP",
+    turn_index=3,
+    comment="Very helpful answer",
+)
+
+# Thumbs-down without a comment
+olakai_feedback(session_id="chat_abc123", rating="DOWN")
+```
+
+---
+
 ### Legacy API (Deprecated)
 
 The v0.4.0 decorator-based API is still available but deprecated. Use the primary API above instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "olakai-sdk"
-version = "1.3.0"
+version = "1.4.0"
 description = "Auto-instrumentation SDK for monitoring and tracking LLM usage (OpenAI, Anthropic, etc.)"
 authors = [
     { name="Olakai", email="support@olakai.ai" }

--- a/src/olakaisdk/__init__.py
+++ b/src/olakaisdk/__init__.py
@@ -20,13 +20,13 @@ from .instrumentation import (
 )
 
 # Legacy API (will be deprecated in future versions)
-from .core import olakai, olakai_event, olakai_monitor
+from .core import olakai, olakai_event, olakai_feedback, olakai_monitor
 from .monitor import olakai_supervisor
 
 # Types
 from .shared import OlakaiBlockedError, MonitorOptions, OlakaiEventParams, OlakaiConfig
 
-__version__ = "1.0.0"
+__version__ = "1.4.0"
 
 __all__ = [
     # Primary API (1.0.0)
@@ -45,6 +45,7 @@ __all__ = [
     "is_openai_instrumented",  # Check if OpenAI is instrumented
     "get_current_context",  # Get current context data
     "olakai_event",
+    "olakai_feedback",  # Report explicit user feedback
     # Legacy API (for backward compatibility)
     "olakai",
     "olakai_monitor",

--- a/src/olakaisdk/core.py
+++ b/src/olakaisdk/core.py
@@ -4,7 +4,7 @@ Core simplified API for the Olakai SDK.
 
 import time
 import asyncio
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, Literal, Optional, Union
 from .shared.types import OlakaiEventParams, MonitorPayload
 from .client.api import send_to_api_simple
 from .config import require_config
@@ -53,6 +53,93 @@ def olakai_event(params: OlakaiEventParams) -> None:
     """
     
     olakai(params)
+
+
+FeedbackRating = Literal["UP", "DOWN"]
+
+
+def olakai_feedback(
+    session_id: str,
+    rating: FeedbackRating,
+    *,
+    turn_index: Optional[int] = None,
+    comment: Optional[str] = None,
+    user_email: Optional[str] = None,
+    custom_data: Optional[Dict[str, Union[str, int, float, bool, None]]] = None,
+) -> None:
+    """Report explicit user feedback on a prior agent interaction.
+
+    Fire-and-forget, like ``olakai_event()``. Never raises — any
+    configuration or transport errors are swallowed so that user
+    code is not affected.
+
+    Under the hood this sends a regular monitoring event with a
+    well-known shape: a sentinel prompt of ``"[feedback]"`` and an
+    empty response, tagged with ``eventType="feedback"`` and the
+    feedback fields in ``customData``. The Olakai backend recognises
+    this shape and routes it to the feedback surface.
+
+    Args:
+        session_id: The session/conversation ID of the interaction
+            being rated. Should match the ``sessionId`` used when
+            reporting the original event.
+        rating: ``"UP"`` or ``"DOWN"`` — the user's feedback.
+        turn_index: Optional zero-based turn index within the
+            session, for turn-level feedback correlation.
+        comment: Optional free-text comment alongside the rating.
+        user_email: Optional override for the user who gave the
+            feedback. Defaults to ``"anonymous@olakai.ai"`` when
+            omitted, matching ``olakai_event()`` behaviour.
+        custom_data: Optional customer-defined fields for domain
+            context. Merged with the well-known feedback fields;
+            caller-provided keys do not override the reserved
+            ``eventType``/``feedbackRating``/``feedbackTurnIndex``/
+            ``feedbackComment`` fields.
+
+    Example:
+        >>> olakai_feedback(
+        ...     session_id="chat_abc123",
+        ...     rating="UP",
+        ...     turn_index=3,
+        ...     comment="Very helpful answer",
+        ... )
+    """
+    try:
+        # Build the well-known feedback customData payload. We start
+        # from the caller's custom_data (if any) so that our reserved
+        # fields always take precedence over user-supplied keys.
+        merged_custom_data: Dict[str, Union[str, int, float, bool, None]] = {}
+        if custom_data:
+            merged_custom_data.update(custom_data)
+
+        merged_custom_data["eventType"] = "feedback"
+        merged_custom_data["feedbackRating"] = rating
+        if turn_index is not None:
+            merged_custom_data["feedbackTurnIndex"] = turn_index
+        if comment is not None:
+            merged_custom_data["feedbackComment"] = comment
+
+        params = OlakaiEventParams(
+            prompt="[feedback]",
+            response="",
+            userEmail=user_email or "anonymous@olakai.ai",
+            sessionId=session_id,
+            customData=merged_custom_data,  # type: ignore[arg-type]
+            shouldScore=False,
+        )
+
+        olakai(params)
+    except Exception as e:  # noqa: BLE001 - fire-and-forget
+        # Never raise from feedback reporting. Best-effort debug log
+        # only if the SDK is configured with debug=True.
+        try:
+            from .config import get_config
+
+            config = get_config()
+            if config is not None and config.debug:
+                print(f"[Olakai SDK] olakai_feedback failed: {e}")
+        except Exception:
+            pass
 
 
 def olakai_monitor(fn: Callable = None, **options):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,7 +8,7 @@ from src.olakaisdk import OlakaiEventParams, __version__
 
 def test_version():
     """Test that version is accessible."""
-    assert __version__ == "1.0.0"
+    assert __version__ == "1.4.0"
 
 
 def test_import():


### PR DESCRIPTION
## Summary

Adds a new public `olakai_feedback()` function for customers to report explicit user feedback (thumbs up/down) on a prior agent interaction. Language parity with the matching `OlakaiSDK.feedback()` method being added to the TypeScript SDK in olakai-ai/olakai-sdk-typescript#39.

## Why

Customers who want to track user ratings on their monitored agents currently have no SDK primitive. They'd have to invent their own convention on top of `olakai_event()` (e.g., using a fake prompt and inventing customData field names). When we audited Kai (Olakai's own assistant, which dogfoods the platform), we found exactly that pattern reaching into internals. This PR fills that product gap with a type-safe, documented primitive.

## API

```python
from olakaisdk import olakai_feedback

olakai_feedback(
    session_id="chat_abc123",
    rating="UP",                     # or "DOWN"
    turn_index=3,                    # optional: which turn in the session
    comment="Very helpful answer",   # optional
    user_email="user@example.com",   # optional
    custom_data={...},               # optional
)
```

- **Fire-and-forget**, never raises.
- **`rating`** is a typed literal: `Literal["UP", "DOWN"]`.
- **Correlation** via `session_id` (required) and `turn_index` (optional).

## Wire format

Emits a standard monitoring event with well-known `customData` keys:

```json
{
  "prompt": "[feedback]",
  "response": "",
  "chat_id": "<session_id>",
  "should_score": false,
  "custom_data": {
    "eventType": "feedback",
    "feedbackRating": "UP",
    "feedbackTurnIndex": 3,
    "feedbackComment": "..."
  }
}
```

No server-side schema changes required. Well-known feedback fields are written AFTER caller-provided `custom_data` so callers cannot accidentally override the markers.

## Version

`1.3.0` → `1.4.0` (minor — additive, backward compatible).

**Note on version drift**: On `main`, `pyproject.toml` was `1.3.0` but `__init__.__version__` had drifted to `1.0.0`. This PR bumps both to `1.4.0` so they agree.

## Parity with TypeScript SDK

| Feature | TypeScript | Python |
|---|---|---|
| Public method name | `OlakaiSDK.feedback()` | `olakai_feedback()` |
| Rating type | `"UP" \| "DOWN"` | `Literal["UP", "DOWN"]` |
| `sessionId` / `session_id` | required | required |
| `turnIndex` / `turn_index` | optional | optional |
| Fire-and-forget | yes | yes |
| `shouldScore` in payload | `false` | `false` |
| Sentinel prompt | `"[feedback]"` | `"[feedback]"` |

## Files changed

- `src/olakaisdk/core.py` — added `FeedbackRating` type alias and `olakai_feedback()` function
- `src/olakaisdk/__init__.py` — export `olakai_feedback`, bump `__version__`
- `pyproject.toml` — version bump
- `README.md` — API reference entry with usage example
- `AGENTS.md` — mention the new public surface
- `CHANGELOG.md` — 1.4.0 entry
- `tests/test_basic.py` — update stale version assertion

## Test plan

- [x] Smoke-validated payload shape locally (minimal/full calls, override protection, empty dict)
- [x] `olakai_feedback` function itself produces zero ruff and zero mypy errors
- [ ] End-to-end: publish 1.4.0 to PyPI, call from a Python project against staging, verify the event shows up

## Known issues (pre-existing, not in this PR)

- `tests/check.sh` is broken on `main` (wrong cd path). Out of scope.
- `pyproject.toml` has `python_version = "3.7"` for mypy but mypy refuses that version. Pre-existing.