### PR TITLE
feat: configurable on-prem host (v1.6.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,10 @@ examples/
 **`src/olakaisdk/config.py`**
 
 - Global configuration management via `_global_config`
-- `olakai_config(api_key, endpoint, debug)`: Initialize SDK
+- `olakai_config(api_key, endpoint=None, debug=False, host=None)`: Initialize SDK
+- `_resolve_endpoint(endpoint, host)`: Resolves the API URL with precedence:
+  explicit `endpoint` → explicit `host` → `OLAKAI_HOST` env var →
+  default `https://app.olakai.ai`. Used to support on-prem deployments.
 - `get_config()`: Get current configuration
 - `require_config()`: Get config or raise error
 - `is_initialized()`: Check if SDK is configured
@@ -205,6 +208,24 @@ examples/
 - Errors in telemetry don't affect user code
 
 ## Important Implementation Details
+
+### Host Resolution (on-prem support)
+
+Both `olakai_config()` and the legacy `init_olakai_client()` resolve the
+target Olakai host with this precedence:
+
+1. **Explicit `endpoint`** (full URL) — wins over everything; rare path,
+   reserved for non-default scheme/path.
+2. **Explicit `host`** (hostname only, e.g. `"olakai.acme.com"`) — preferred
+   for on-prem deployments. The SDK prepends `https://`.
+3. **`OLAKAI_HOST` env var** — same semantics as the `host` arg; lets ops
+   set the on-prem host without code changes.
+4. **Default** — `app.olakai.ai` (SaaS).
+
+The resolved endpoint is used in `client/api.py` to build
+`/api/monitoring/prompt`, `/api/control/prompt`, and
+`/api/monitoring/feedback` URLs. This mirrors the TypeScript SDK's
+`host` / `OLAKAI_HOST` behavior.
 
 ### Thread Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to the Olakai Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-05-04
+
+### Added
+
+- **On-prem host configuration.** `olakai_config()` now accepts a `host`
+  keyword argument (hostname only, e.g. `"olakai.acme.com"`) and falls
+  back to the `OLAKAI_HOST` environment variable when neither `host` nor
+  `endpoint` is provided. Useful for self-hosted Olakai deployments.
+  - Resolution precedence: explicit `endpoint` → explicit `host` →
+    `OLAKAI_HOST` env var → default `app.olakai.ai`.
+  - The resolved endpoint is used to derive monitoring, control, and
+    feedback URLs — single point of configuration.
+  - `endpoint` parameter is now `Optional[str]` (was a positional default).
+  - Legacy `init_olakai_client()` accepts a bare hostname (e.g.
+    `"olakai.acme.com"`) for `domain`, and falls back to `OLAKAI_HOST`
+    when `domain` is omitted.
+- **Robust URL parsing for `host` and `OLAKAI_HOST`.** Inputs are now
+  parsed with `urllib.parse.urlparse`, accepting either a bare hostname
+  (`olakai.acme.com`) or a full URL (`https://olakai.acme.com/api/v1`).
+  For full URLs, only the origin is kept — paths, queries, and trailing
+  slashes are stripped. Explicit `endpoint` retains any embedded path
+  (back-compat) but trailing slashes are stripped.
+- **Loopback hosts default to `http://`.** Bare `localhost`,
+  `127.0.0.1`, and `[::1]` (with optional port) now resolve to `http://`
+  instead of `https://`. Local Olakai dev servers don't usually have TLS,
+  so the previous default produced TLS handshake failures. Pass an
+  explicit `https://` prefix to override.
+
+### Changed
+
+- **Fire-and-forget telemetry never raises.** `send_to_api_simple()`
+  now swallows transport, retry, and HTTP errors and returns ``None``
+  on any failure (matching `send_feedback_to_api()` and the TypeScript
+  SDK contract). Previously a failed monitoring call could escape into
+  user code through the instrumentation layer's error handler.
+
+### Fixed
+
+- `init_olakai_client()` now imports `olakai_config` from `..config`
+  (previously imported from `..core` where it does not live — would have
+  raised `ImportError` when called).
+- `get_olakai_client()` now imports `get_config` from `..config`
+  (same latent bug — worked only by accident because `core.py` re-imports
+  the symbol).
+- `host`/`OLAKAI_HOST` containing a scheme prefix (e.g.
+  `"https://olakai.acme.com"`) no longer produces malformed URLs
+  (`https://https://olakai.acme.com`).
+- Trailing slashes in `endpoint`, `host`, or `OLAKAI_HOST` no longer
+  produce double slashes (`https://acme.com//api/monitoring/prompt`)
+  in derived URLs.
+- Empty-string `endpoint` (e.g. from a missing-defaulted env var) now
+  falls through to `host` / `OLAKAI_HOST` / default instead of producing
+  relative URLs like `/api/monitoring/prompt`.
+- Userinfo (`user:pass@`) in `host` / `OLAKAI_HOST` URLs is now stripped
+  during normalization, keeping credentials out of the resolved endpoint
+  and out of debug logs. IPv6 brackets and explicit ports are preserved.
+- `host` / `OLAKAI_HOST` URLs with non-http(s) schemes (e.g. `ftp://`,
+  `file://`) now raise `URLConfigurationError` at config time instead
+  of failing with a less-actionable error at request time.
+- `endpoint` is now validated symmetrically with `host`: it must be a
+  full URL with an http(s) scheme. Non-http(s) schemes and bare
+  hostnames passed via `endpoint` raise `URLConfigurationError` at
+  config time. (Previously `endpoint="ftp://x"` or
+  `endpoint="bare-host"` would silently produce malformed requests.)
+  The legacy `init_olakai_client(api_key, domain=...)` shim is
+  affected too: a `domain` value containing `://` but using a
+  non-http(s) scheme now raises at config time.
+- URL-validation errors are now raised as `URLConfigurationError`
+  (already part of the SDK exception hierarchy under `OlakaiSDKError`),
+  not bare `ValueError`. Customers can catch all init errors via the
+  shared `OlakaiSDKError` base class.
+
+### Example
+
+```python
+# SaaS (default)
+olakai_config("your-api-key")
+
+# On-prem via host arg
+olakai_config("your-api-key", host="olakai.acme.com")
+
+# On-prem via env var: OLAKAI_HOST=olakai.acme.com
+olakai_config("your-api-key")
+```
+
 ## [1.5.0] - 2026-04-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -247,15 +247,25 @@ asyncio.run(main())
 ```python
 from olakaisdk import olakai_config
 
-# Basic configuration
+# Basic configuration (SaaS — defaults to app.olakai.ai)
 olakai_config("your-api-key")
 
-# With custom endpoint
+# On-prem deployment via host argument
+olakai_config("your-api-key", host="olakai.acme.com")
+
+# On-prem deployment via OLAKAI_HOST env var (no host arg needed)
+#   $ export OLAKAI_HOST=olakai.acme.com
+olakai_config("your-api-key")
+
+# Full endpoint override (rarely needed; for non-default scheme/path)
 olakai_config("your-api-key", endpoint="https://custom.olakai.ai")
 
 # With debug logging
 olakai_config("your-api-key", debug=True)
 ```
+
+**Host resolution precedence:** explicit `endpoint` → explicit `host` →
+`OLAKAI_HOST` env var → default `app.olakai.ai`.
 
 ### Instrumentation Options
 
@@ -291,15 +301,20 @@ instrument_openai(
 
 ### Primary API (v1.0.0)
 
-#### `olakai_config(api_key, endpoint="https://app.olakai.ai", debug=False)`
+#### `olakai_config(api_key, endpoint=None, debug=False, host=None)`
 
 Initialize the Olakai SDK. Must be called before instrumentation.
 
 **Parameters:**
 
 - `api_key` (str): Your Olakai API key
-- `endpoint` (str, optional): API endpoint URL
+- `endpoint` (str, optional): Full API endpoint URL. If omitted, derived
+  from `host` / `OLAKAI_HOST` env var / default `https://app.olakai.ai`.
+  Use this only when you need a non-default scheme or path.
 - `debug` (bool, optional): Enable debug logging
+- `host` (str, optional): Olakai hostname only (e.g. `"olakai.acme.com"`)
+  for on-prem deployments. Falls back to the `OLAKAI_HOST` env var, then
+  `"app.olakai.ai"`. Ignored if `endpoint` is provided.
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -990,25 +990,30 @@ if __name__ == "__main__":
 import os
 
 def get_olakai_config():
-    """Get configuration based on environment."""
+    """Get configuration based on environment.
+
+    Tip: in many deployments you can skip this entirely and just set
+    the `OLAKAI_HOST` env var per-environment — the SDK will pick it up
+    automatically from `olakai_config(api_key)`.
+    """
     env = os.getenv("ENVIRONMENT", "development")
 
     if env == "production":
         return {
             "api_key": os.getenv("OLAKAI_API_KEY"),
-            "endpoint": "https://app.olakai.ai",
+            "host": "app.olakai.ai",
             "debug": False
         }
     elif env == "staging":
         return {
             "api_key": os.getenv("OLAKAI_STAGING_KEY"),
-            "endpoint": "https://staging.olakai.ai",
+            "host": "staging.olakai.ai",
             "debug": True
         }
     else:  # development
         return {
             "api_key": os.getenv("OLAKAI_DEV_KEY", "dev-key"),
-            "endpoint": "https://dev.olakai.ai",
+            "host": "dev.olakai.ai",
             "debug": True
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "olakai-sdk"
-version = "1.5.0"
+version = "1.6.0"
 description = "Auto-instrumentation SDK for monitoring and tracking LLM usage (OpenAI, Anthropic, etc.)"
 authors = [
     { name="Olakai", email="support@olakai.ai" }

--- a/src/olakaisdk/__init__.py
+++ b/src/olakaisdk/__init__.py
@@ -31,7 +31,7 @@ from .shared import (
     OlakaiConfig,
 )
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 __all__ = [
     # Primary API (1.0.0)

--- a/src/olakaisdk/client/api.py
+++ b/src/olakaisdk/client/api.py
@@ -3,7 +3,7 @@ Simplified API communication module for the Olakai SDK.
 """
 
 from dataclasses import asdict
-from typing import Any, Dict, Union, Literal
+from typing import Any, Dict, Optional, Union, Literal
 import asyncio
 from ..shared import (
     APITimeoutError,
@@ -145,14 +145,20 @@ async def send_with_retry(
 async def send_to_api_simple(
     config: OlakaiConfig,
     payload: MonitorPayload,
-) -> Union[APIResponse, ControlResponse]:
-    """Send payload to API with simplified logic."""
+) -> Optional[Union[APIResponse, ControlResponse]]:
+    """Send payload to monitoring API.
+
+    Fire-and-forget: any transport, retry, or HTTP errors are swallowed so
+    that user code is never affected by telemetry failures. Returns the
+    response on success or ``None`` on any failure. Callers are not expected
+    to use the return value.
+    """
     try:
         return await send_with_retry(config, payload, "monitoring")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - fire-and-forget telemetry
         if config.debug:
             print(f"[Olakai SDK] Error sending payload to API: {e}")
-        raise e
+        return None
 
 
 async def send_feedback_to_api(
@@ -204,8 +210,12 @@ async def send_to_api(
     config: OlakaiConfig,
     payload: Union[MonitorPayload, ControlPayload],
     options: dict = {},
-) -> Union[APIResponse, ControlResponse]:
-    """Send payload to API (legacy function for backward compatibility)."""
+) -> Optional[Union[APIResponse, ControlResponse]]:
+    """Send payload to API (legacy function for backward compatibility).
+
+    For monitoring payloads this is fire-and-forget — the return value may
+    be ``None`` on any failure. For control payloads, errors propagate.
+    """
     if isinstance(payload, MonitorPayload):
         return await send_to_api_simple(config, payload)
     else:

--- a/src/olakaisdk/client/client.py
+++ b/src/olakaisdk/client/client.py
@@ -2,35 +2,55 @@
 Simplified client for the Olakai SDK.
 """
 
+from typing import Optional
+
 from ..shared import (
     InitializationError,
 )
 
 
-def init_olakai_client(api_key: str, domain: str = "https://app.olakai.ai", **kwargs):
+def init_olakai_client(api_key: str, domain: Optional[str] = None, **kwargs):
     """
     Initialize the Olakai SDK client (legacy function for backward compatibility).
-    
+
     Args:
         api_key: Your Olakai API key
-        domain: API domain
+        domain: API domain (full URL or bare hostname). If omitted, the
+            target host is resolved from the `OLAKAI_HOST` env var, falling
+            back to "app.olakai.ai". Bare hostnames go through the same
+            normalization as `olakai_config(host=...)` (loopback hosts
+            default to http://, others to https://). Full URLs preserve
+            any embedded path for backward compatibility.
         **kwargs: Additional configuration (ignored in simplified version)
     """
-    from ..core import olakai_config
-    
-    # Convert domain to endpoint format
-    endpoint = domain if domain.startswith("http") else f"https://{domain}"
-    
-    # Initialize with simplified config
-    olakai_config(api_key, endpoint, debug=kwargs.get("debug", False))
+    from ..config import olakai_config
+
+    if domain is None:
+        olakai_config(api_key, debug=kwargs.get("debug", False))
+        return
+
+    # Bare hostname → use `host` so loopback http:// special-case applies.
+    # Full URL → use `endpoint` so embedded paths are preserved (legacy).
+    if "://" in domain:
+        olakai_config(
+            api_key,
+            endpoint=domain,
+            debug=kwargs.get("debug", False),
+        )
+    else:
+        olakai_config(
+            api_key,
+            host=domain,
+            debug=kwargs.get("debug", False),
+        )
 
 
 def get_olakai_client():
     """
     Get the global Olakai client instance (legacy function for backward compatibility).
     """
-    from ..core import get_config
-    
+    from ..config import get_config
+
     config = get_config()
     if config is None:
         raise InitializationError(

--- a/src/olakaisdk/config.py
+++ b/src/olakaisdk/config.py
@@ -1,17 +1,100 @@
 """Global configuration for Olakai SDK."""
 
+import os
+import re
 from typing import Optional
+from urllib.parse import urlparse
+
 from .shared.types import OlakaiConfig
-from .shared.exceptions import APIKeyMissingError
+from .shared.exceptions import APIKeyMissingError, URLConfigurationError
 
 
 _global_config: Optional[OlakaiConfig] = None
 
+DEFAULT_HOST = "app.olakai.ai"
+
+# Loopback hostnames default to http:// because local Olakai dev servers
+# (e.g. `pnpm dev` on `localhost:3000`) don't usually have TLS.
+# Match `localhost`, `127.0.0.1`, or IPv6 `[::1]`, with an optional port.
+_LOOPBACK_HOST_RE = re.compile(
+    r"^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$",
+    re.IGNORECASE,
+)
+
+
+def _normalize_host(raw: str) -> str:
+    """Normalize a `host` value into a `scheme://host[:port]` origin.
+
+    Accepts a bare hostname (`olakai.acme.com`) or a full URL
+    (`https://olakai.acme.com/api/v1`). For full URLs, only the origin is
+    kept — paths, queries, and any userinfo (`user:pass@`) are stripped to
+    avoid leaking credentials into debug logs. Bare hostnames default to
+    `https://` except loopback hosts (`localhost`, `127.0.0.1`, `[::1]`,
+    with optional port) which default to `http://` for local-dev convenience.
+
+    Raises:
+        URLConfigurationError: if the input is not a valid http/https URL.
+    """
+    raw = raw.strip().rstrip("/")
+    if "://" in raw:
+        parsed = urlparse(raw)
+        if not parsed.netloc:
+            raise URLConfigurationError(f"Invalid URL: {raw}")
+        if parsed.scheme not in ("http", "https"):
+            raise URLConfigurationError(
+                f"Unsupported URL scheme '{parsed.scheme}' (expected http or https): {raw}"
+            )
+        # Strip userinfo (everything before "@") to keep credentials out of
+        # the resolved endpoint and out of debug logs. Preserves IPv6
+        # brackets and explicit ports because we keep the rest of netloc
+        # verbatim.
+        netloc = parsed.netloc.rsplit("@", 1)[-1]
+        return f"{parsed.scheme}://{netloc}"
+    scheme = "http" if _LOOPBACK_HOST_RE.match(raw) else "https"
+    return f"{scheme}://{raw}"
+
+
+def _resolve_endpoint(endpoint: Optional[str], host: Optional[str]) -> str:
+    """
+    Resolve the API endpoint URL.
+
+    Precedence: explicit `endpoint` (full URL, may include path) →
+    explicit `host` (bare hostname or full URL — origin-only) →
+    `OLAKAI_HOST` env var → default `https://app.olakai.ai`.
+
+    Trailing slashes are stripped so callers can safely append `/api/...`.
+    Empty-string `endpoint` is treated as "not provided" rather than as a
+    valid relative-URL endpoint.
+
+    Raises:
+        URLConfigurationError: if `endpoint`, `host`, or `OLAKAI_HOST` is
+            not a valid http/https URL.
+    """
+    if endpoint:
+        # `endpoint` preserves any embedded path (legacy contract), but it
+        # must still be an http(s) URL — bare hostnames or non-http schemes
+        # would silently produce malformed requests downstream.
+        if "://" in endpoint:
+            scheme = urlparse(endpoint).scheme
+            if scheme not in ("http", "https"):
+                raise URLConfigurationError(
+                    f"Unsupported URL scheme '{scheme}' (expected http or https): {endpoint}"
+                )
+        else:
+            raise URLConfigurationError(
+                f"`endpoint` must be a full URL with http(s) scheme: {endpoint}. "
+                f"Pass a bare hostname via `host=` instead."
+            )
+        return endpoint.rstrip("/")
+    raw = host or os.environ.get("OLAKAI_HOST") or DEFAULT_HOST
+    return _normalize_host(raw)
+
 
 def olakai_config(
     api_key: str,
-    endpoint: str = "https://app.olakai.ai",
-    debug: bool = False
+    endpoint: Optional[str] = None,
+    debug: bool = False,
+    host: Optional[str] = None,
 ) -> None:
     """
     Initialize the Olakai SDK.
@@ -21,14 +104,28 @@ def olakai_config(
 
     Args:
         api_key: Your Olakai API key
-        endpoint: API endpoint URL (default: https://app.olakai.ai)
+        endpoint: Full API endpoint URL with http(s) scheme
+            (e.g. "https://app.olakai.ai"). If omitted, derived from
+            `host` / `OLAKAI_HOST` env var / default "app.olakai.ai".
+            Use this only when you need a non-default URL path;
+            otherwise prefer `host`.
         debug: Enable debug logging (default: False)
+        host: Olakai hostname only (e.g. "olakai.acme.com"). For on-prem
+            deployments. Falls back to the `OLAKAI_HOST` env var, then
+            "app.olakai.ai". Ignored if `endpoint` is provided.
 
     Raises:
-        APIKeyMissingError: If api_key is empty or None
+        APIKeyMissingError: If api_key is empty or None.
+        URLConfigurationError: If `endpoint`, `host`, or `OLAKAI_HOST`
+            is not a valid http/https URL.
 
     Example:
         >>> from olakaisdk import olakai_config
+        >>> # SaaS default
+        >>> olakai_config("your-api-key")
+        >>> # On-prem via host arg
+        >>> olakai_config("your-api-key", host="olakai.acme.com")
+        >>> # On-prem via OLAKAI_HOST env var (no host arg needed)
         >>> olakai_config("your-api-key", debug=True)
     """
     global _global_config
@@ -36,14 +133,16 @@ def olakai_config(
     if not api_key:
         raise APIKeyMissingError("API key is required to initialize the Olakai SDK")
 
+    resolved_endpoint = _resolve_endpoint(endpoint, host)
+
     _global_config = OlakaiConfig(
         api_key=api_key,
-        endpoint=endpoint,
-        debug=debug
+        endpoint=resolved_endpoint,
+        debug=debug,
     )
 
     if debug:
-        print(f"[Olakai SDK] SDK initialized with endpoint: {endpoint}")
+        print(f"[Olakai SDK] SDK initialized with endpoint: {resolved_endpoint}")
 
 
 def get_config() -> Optional[OlakaiConfig]:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,7 +7,7 @@ from src.olakaisdk import OlakaiEventParams, __version__
 
 def test_version():
     """Test that version is accessible."""
-    assert __version__ == "1.5.0"
+    assert __version__ == "1.6.0"
 
 
 def test_import():


### PR DESCRIPTION
## Summary

Adds a `host` keyword argument to `olakai_config()` and an `OLAKAI_HOST` environment variable so customer apps can point the SDK at an on-prem Olakai deployment instead of `app.olakai.ai`. Mirrors the TypeScript SDK's 2.6.0 API.

**Resolution precedence:**
explicit `endpoint` → explicit `host` → `OLAKAI_HOST` env var → default `app.olakai.ai`

## Usage

```python
from olakaisdk import olakai_config

# SaaS (default, unchanged)
olakai_config("your-api-key")

# On-prem via host arg
olakai_config("your-api-key", host="olakai.acme.com")

# On-prem via env var: OLAKAI_HOST=olakai.acme.com
olakai_config("your-api-key")
```

## Side cleanups bundled in

- **Robust URL parsing** via `urllib.parse.urlparse`. Accepts bare hostnames or full URLs. Trailing slashes stripped. Embedded paths/queries dropped from `host` (origin-only).
- **Loopback http://** — `localhost`, `127.0.0.1`, `[::1]` (with optional port) default to `http://` for local-dev convenience. Pass an explicit `https://` prefix to override.
- **Credentials safety** — userinfo (`user:pass@`) stripped from URLs to keep credentials out of debug logs. IPv6 brackets and explicit ports preserved.
- **Symmetric scheme validation** — `endpoint`, `host`, and `OLAKAI_HOST` must all be http(s). Non-http(s) schemes (`ftp://`, `file://`, etc.) raise `URLConfigurationError` at config time instead of failing later at request time.
- **Empty-string `endpoint` falls through** — fixes the case where `endpoint=os.environ.get("OLAKAI_ENDPOINT", "")` would produce relative URLs like `/api/monitoring/prompt`.
- **Fire-and-forget telemetry never raises** — `send_to_api_simple()` swallows transport/HTTP errors and returns `None`. Matches `send_feedback_to_api()` and the TypeScript SDK contract.

## Bug fixes

- `init_olakai_client()` and `get_olakai_client()` now import `olakai_config` / `get_config` from `..config` (was `..core`, which worked only by accident through re-export — would have raised `ImportError` if call order ever shifted).
- `host` / `OLAKAI_HOST` containing a scheme prefix no longer produces malformed URLs (`https://https://olakai.acme.com`).

## Backward compatibility

- Existing `endpoint` callers still work; `endpoint` retains its embedded-path semantics. `endpoint` is now `Optional[str]` (was a positional default), but positional callers continue to work.
- The legacy `init_olakai_client(api_key, domain)` shim accepts bare hostnames or full URLs.
- **Breaking for malformed configs only**: Non-http(s) values for `endpoint`, `host`, `OLAKAI_HOST`, or `init_olakai_client(domain=...)` now raise at config time instead of failing later. Real customer code should not be affected.

## Test plan

- [x] `ruff check` clean
- [x] `mypy --ignore-missing-imports` clean
- [x] Full test suite: 75 passed
- [x] Smoke tests for resolution logic: default, bare hostname, full URL, URL with path, trailing slash, query string, env var, loopback (localhost / 127.0.0.1 / [::1]), loopback subdomain (not loopback), explicit scheme override, OLAKAI_HOST env, endpoint precedence, init_olakai_client integration
- [x] Smoke tests for new validation: empty-string endpoint fallthrough, userinfo stripped (with IPv6 + ports preserved), non-http(s) scheme rejected via `host` and via `endpoint`, bare hostname via `endpoint` rejected
- [ ] Verify against on-prem deployment in staging
- [ ] Update `localnode-app/packages/config/sdk-versions.ts` to `1.6.0` after publish (already drafted, uncommitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)