### PR TITLE
fix: omit null modelName from monitoring payload

### DIFF
--- a/src/olakaisdk/client/api.py
+++ b/src/olakaisdk/client/api.py
@@ -56,6 +56,8 @@ async def make_api_call(
             del data_dict["customData"]
         if "shouldScore" in data_dict and data_dict["shouldScore"] is None:
             del data_dict["shouldScore"]
+        if "modelName" in data_dict and data_dict["modelName"] is None:
+            del data_dict["modelName"]
     else:
         if (
             "overrideControlCriteria" in data_dict


### PR DESCRIPTION
## Summary
- The backend rejects monitoring payloads where `modelName` is `null` (must be a string or absent).
- Only the OpenAI/Anthropic/Google extractors populate `modelName`. Direct `olakai_event()` and `olakai_monitor()` calls left it unset, and `asdict(payload)` serialized the default `None` as `"modelName": null`.
- Strip `modelName` from the payload when `None`, mirroring the existing handling for `errorMessage`, `taskExecutionId`, `task`, `subTask`, `customData`, and `shouldScore`.

## Test plan
- [x] `python3 -m pytest -v` — all 75 tests pass
- [ ] Verify a manual `olakai_event()` call no longer includes `"modelName": null` on the wire
- [ ] Verify the OpenAI auto-instrumentation path still sends a string `modelName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)